### PR TITLE
Add patient intake form backend API

### DIFF
--- a/backend/alembic/versions/0009_patient_intake_forms.py
+++ b/backend/alembic/versions/0009_patient_intake_forms.py
@@ -1,0 +1,75 @@
+"""Add intake_tokens and intake_submissions tables.
+
+Revision ID: 0009
+Revises: 0008
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "intake_tokens",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("practitioner_id", sa.Integer, sa.ForeignKey("practitioners.id"), nullable=False, index=True),
+        sa.Column("token", sa.String(128), unique=True, nullable=False),
+        sa.Column("active", sa.Boolean, default=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "intake_submissions",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("practitioner_id", sa.Integer, sa.ForeignKey("practitioners.id"), nullable=False, index=True),
+        sa.Column("token_id", sa.Integer, sa.ForeignKey("intake_tokens.id"), nullable=False, unique=True),
+        sa.Column("status", sa.Enum("pending", "reviewed", "approved", "rejected", name="intakestatus"), nullable=False, server_default="pending"),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True)),
+        # Demographics
+        sa.Column("first_name", sa.String(80), nullable=False),
+        sa.Column("last_name", sa.String(80), nullable=False),
+        sa.Column("dob", sa.Date),
+        sa.Column("sex", sa.String(10)),
+        sa.Column("email", sa.String(200)),
+        sa.Column("phone", sa.String(30)),
+        sa.Column("address", sa.String(500)),
+        sa.Column("occupation", sa.String(200)),
+        # Medical history
+        sa.Column("current_medications", sa.Text),
+        sa.Column("allergies", sa.Text),
+        sa.Column("past_surgeries", sa.Text),
+        sa.Column("chronic_conditions", sa.Text),
+        sa.Column("family_history", sa.Text),
+        # Lifestyle
+        sa.Column("diet_type", sa.String(50)),
+        sa.Column("exercise_habits", sa.Text),
+        sa.Column("sleep_patterns", sa.Text),
+        sa.Column("stress_level", sa.Integer),
+        sa.Column("smoking", sa.String(50)),
+        sa.Column("alcohol", sa.String(50)),
+        sa.Column("caffeine", sa.String(50)),
+        # Ayurvedic
+        sa.Column("digestive_patterns", sa.Text),
+        sa.Column("elimination_patterns", sa.Text),
+        sa.Column("energy_levels", sa.Text),
+        sa.Column("mental_tendencies", sa.Text),
+        sa.Column("prior_ayurvedic_care", sa.Text),
+        # Reason for visit
+        sa.Column("chief_concern", sa.Text),
+        sa.Column("symptom_duration", sa.String(200)),
+        sa.Column("previous_treatments", sa.Text),
+        sa.Column("treatment_goals", sa.Text),
+        # Rejection
+        sa.Column("rejection_reason", sa.Text),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("intake_submissions")
+    op.drop_table("intake_tokens")
+    op.execute("DROP TYPE IF EXISTS intakestatus")

--- a/backend/app/api/routes/intake.py
+++ b/backend/app/api/routes/intake.py
@@ -1,0 +1,366 @@
+"""
+Patient intake form routes.
+- Practitioner endpoints: generate links, list/review/approve/reject submissions
+- Public endpoints: load form, submit intake
+"""
+from datetime import datetime, date, timezone
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+from pydantic import BaseModel
+
+from app.core.database import get_db
+from app.models.intake import IntakeToken, IntakeSubmission, IntakeStatus
+from app.models.patient import Patient, HealthProfile
+from app.models.checkin import CheckInToken
+from app.models.practitioner import Practitioner
+from app.api.deps import get_current_practitioner, require_active_subscription, check_patient_limit
+
+router = APIRouter()
+
+
+# ── Schemas ────────────────────────────────────────────────────────────────────
+
+class IntakeSubmitBody(BaseModel):
+    # Demographics (required)
+    first_name: str
+    last_name:  str
+    # Demographics (optional)
+    dob:        date | None = None
+    sex:        str | None = None
+    email:      str | None = None
+    phone:      str | None = None
+    address:    str | None = None
+    occupation: str | None = None
+    # Medical history
+    current_medications: str | None = None
+    allergies:           str | None = None
+    past_surgeries:      str | None = None
+    chronic_conditions:  str | None = None
+    family_history:      str | None = None
+    # Lifestyle
+    diet_type:       str | None = None
+    exercise_habits: str | None = None
+    sleep_patterns:  str | None = None
+    stress_level:    int | None = None
+    smoking:         str | None = None
+    alcohol:         str | None = None
+    caffeine:        str | None = None
+    # Ayurvedic (optional)
+    digestive_patterns:   str | None = None
+    elimination_patterns: str | None = None
+    energy_levels:        str | None = None
+    mental_tendencies:    str | None = None
+    prior_ayurvedic_care: str | None = None
+    # Reason for visit
+    chief_concern:       str | None = None
+    symptom_duration:    str | None = None
+    previous_treatments: str | None = None
+    treatment_goals:     str | None = None
+
+
+class RejectBody(BaseModel):
+    reason: str | None = None
+
+
+# ── Token resolution helper (public) ──────────────────────────────────────────
+
+async def _resolve_intake_token(token: str, db: AsyncSession) -> IntakeToken:
+    result = await db.execute(
+        select(IntakeToken)
+        .options(selectinload(IntakeToken.practitioner), selectinload(IntakeToken.submission))
+        .where(IntakeToken.token == token, IntakeToken.active == True)
+    )
+    tok = result.scalars().first()
+    if not tok:
+        raise HTTPException(status_code=404, detail="Invalid or expired intake link")
+    return tok
+
+
+# ── Public routes (no auth) ───────────────────────────────────────────────────
+
+@router.get("/form/{token}")
+async def get_intake_form(token: str, db: AsyncSession = Depends(get_db)):
+    """Load intake form — returns practitioner branding and whether already submitted."""
+    tok = await _resolve_intake_token(token, db)
+    practitioner = tok.practitioner
+
+    return {
+        "token": tok.token,
+        "already_submitted": tok.submission is not None,
+        "practice": {
+            "name": practitioner.practice_name or practitioner.name,
+            "logo_url": practitioner.practice_logo_url,
+            "tagline": practitioner.tagline,
+            "practitioner_name": practitioner.name,
+            "designation": practitioner.designation,
+        },
+    }
+
+
+@router.post("/form/{token}/submit", status_code=201)
+async def submit_intake_form(token: str, body: IntakeSubmitBody, db: AsyncSession = Depends(get_db)):
+    """Patient submits their completed intake form."""
+    tok = await _resolve_intake_token(token, db)
+
+    if tok.submission is not None:
+        raise HTTPException(status_code=409, detail="This intake form has already been submitted")
+
+    submission = IntakeSubmission(
+        practitioner_id=tok.practitioner_id,
+        token_id=tok.id,
+        **body.model_dump(),
+    )
+    db.add(submission)
+    await db.flush()
+
+    # Deactivate token after successful submission
+    tok.active = False
+
+    return {"message": "Intake form submitted successfully", "submission_id": submission.id}
+
+
+# ── Practitioner routes (auth required) ───────────────────────────────────────
+
+@router.post("/generate-link")
+async def generate_intake_link(
+    db: AsyncSession = Depends(get_db),
+    current: Practitioner = Depends(require_active_subscription),
+):
+    """Generate a new intake form link for a prospective patient."""
+    tok = IntakeToken(practitioner_id=current.id)
+    db.add(tok)
+    await db.flush()
+
+    return {
+        "token": tok.token,
+        "intake_url_path": tok.intake_url_path,
+    }
+
+
+@router.get("/submissions")
+async def list_submissions(
+    status_filter: IntakeStatus | None = None,
+    db: AsyncSession = Depends(get_db),
+    current: Practitioner = Depends(require_active_subscription),
+):
+    """List all intake submissions for this practitioner."""
+    query = (
+        select(IntakeSubmission)
+        .where(IntakeSubmission.practitioner_id == current.id)
+        .order_by(IntakeSubmission.submitted_at.desc())
+    )
+    if status_filter:
+        query = query.where(IntakeSubmission.status == status_filter)
+
+    result = await db.execute(query)
+    submissions = result.scalars().all()
+
+    return [_submission_summary(s) for s in submissions]
+
+
+@router.get("/submissions/{submission_id}")
+async def get_submission(
+    submission_id: int,
+    db: AsyncSession = Depends(get_db),
+    current: Practitioner = Depends(require_active_subscription),
+):
+    """View a single intake submission in full detail."""
+    submission = await _get_submission_or_404(db, submission_id, current.id)
+    return _submission_detail(submission)
+
+
+@router.post("/submissions/{submission_id}/review")
+async def mark_reviewed(
+    submission_id: int,
+    db: AsyncSession = Depends(get_db),
+    current: Practitioner = Depends(require_active_subscription),
+):
+    """Mark a submission as reviewed (seen but not yet decided)."""
+    submission = await _get_submission_or_404(db, submission_id, current.id)
+
+    if submission.status != IntakeStatus.PENDING:
+        raise HTTPException(status_code=400, detail=f"Cannot review a submission with status '{submission.status.value}'")
+
+    submission.status = IntakeStatus.REVIEWED
+    submission.reviewed_at = datetime.now(timezone.utc)
+
+    return {"message": "Submission marked as reviewed"}
+
+
+@router.post("/submissions/{submission_id}/approve")
+async def approve_submission(
+    submission_id: int,
+    db: AsyncSession = Depends(get_db),
+    current: Practitioner = Depends(check_patient_limit),
+):
+    """Approve a submission — creates a Patient + HealthProfile from the intake data."""
+    submission = await _get_submission_or_404(db, submission_id, current.id)
+
+    if submission.status == IntakeStatus.APPROVED:
+        raise HTTPException(status_code=400, detail="This submission has already been approved")
+    if submission.status == IntakeStatus.REJECTED:
+        raise HTTPException(status_code=400, detail="Cannot approve a rejected submission")
+
+    # Create Patient from submission demographics + lifestyle
+    patient = Patient(
+        practitioner_id=current.id,
+        first_name=submission.first_name,
+        last_name=submission.last_name,
+        dob=submission.dob,
+        sex=submission.sex,
+        email=submission.email,
+        phone=submission.phone,
+        location=submission.address,
+        occupation=submission.occupation,
+        exercise_notes=submission.exercise_habits,
+        diet_pattern=submission.diet_type,
+        sleep_notes=submission.sleep_patterns,
+        stress_level=str(submission.stress_level) if submission.stress_level else None,
+    )
+    db.add(patient)
+    await db.flush()
+
+    # Create HealthProfile from medical history + Ayurvedic data
+    hp = HealthProfile(
+        patient_id=patient.id,
+        chief_complaints=submission.chief_concern,
+        medical_history=_build_medical_history(submission),
+        current_medications=submission.current_medications,
+        allergies=submission.allergies,
+    )
+    db.add(hp)
+
+    # Auto-create check-in token for the new patient
+    checkin_tok = CheckInToken(patient_id=patient.id)
+    db.add(checkin_tok)
+
+    # Update submission status
+    submission.status = IntakeStatus.APPROVED
+    submission.reviewed_at = datetime.now(timezone.utc)
+
+    await db.flush()
+
+    return {
+        "message": "Submission approved — patient record created",
+        "patient_id": patient.id,
+    }
+
+
+@router.post("/submissions/{submission_id}/reject")
+async def reject_submission(
+    submission_id: int,
+    body: RejectBody,
+    db: AsyncSession = Depends(get_db),
+    current: Practitioner = Depends(require_active_subscription),
+):
+    """Reject a submission with an optional reason."""
+    submission = await _get_submission_or_404(db, submission_id, current.id)
+
+    if submission.status == IntakeStatus.APPROVED:
+        raise HTTPException(status_code=400, detail="Cannot reject an already-approved submission")
+
+    submission.status = IntakeStatus.REJECTED
+    submission.reviewed_at = datetime.now(timezone.utc)
+    submission.rejection_reason = body.reason
+
+    return {"message": "Submission rejected"}
+
+
+@router.delete("/submissions/{submission_id}", status_code=204)
+async def delete_submission(
+    submission_id: int,
+    db: AsyncSession = Depends(get_db),
+    current: Practitioner = Depends(require_active_subscription),
+):
+    """Delete a submission (only pending or rejected)."""
+    submission = await _get_submission_or_404(db, submission_id, current.id)
+
+    if submission.status == IntakeStatus.APPROVED:
+        raise HTTPException(status_code=400, detail="Cannot delete an approved submission")
+
+    await db.delete(submission)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+async def _get_submission_or_404(db: AsyncSession, submission_id: int, practitioner_id: int) -> IntakeSubmission:
+    result = await db.execute(
+        select(IntakeSubmission).where(
+            IntakeSubmission.id == submission_id,
+            IntakeSubmission.practitioner_id == practitioner_id,
+        )
+    )
+    s = result.scalar_one_or_none()
+    if not s:
+        raise HTTPException(status_code=404, detail="Submission not found")
+    return s
+
+
+def _build_medical_history(s: IntakeSubmission) -> str | None:
+    """Combine intake medical history fields into a single text block."""
+    parts = []
+    if s.past_surgeries:
+        parts.append(f"Past surgeries: {s.past_surgeries}")
+    if s.chronic_conditions:
+        parts.append(f"Chronic conditions: {s.chronic_conditions}")
+    if s.family_history:
+        parts.append(f"Family history: {s.family_history}")
+    if s.previous_treatments:
+        parts.append(f"Previous treatments: {s.previous_treatments}")
+    return "\n".join(parts) if parts else None
+
+
+def _submission_summary(s: IntakeSubmission) -> dict:
+    return {
+        "id": s.id,
+        "first_name": s.first_name,
+        "last_name": s.last_name,
+        "full_name": f"{s.first_name} {s.last_name}",
+        "email": s.email,
+        "phone": s.phone,
+        "status": s.status.value,
+        "submitted_at": s.submitted_at.isoformat(),
+        "reviewed_at": s.reviewed_at.isoformat() if s.reviewed_at else None,
+        "chief_concern": s.chief_concern,
+    }
+
+
+def _submission_detail(s: IntakeSubmission) -> dict:
+    base = _submission_summary(s)
+    base.update({
+        # Demographics
+        "dob": s.dob.isoformat() if s.dob else None,
+        "sex": s.sex,
+        "address": s.address,
+        "occupation": s.occupation,
+        # Medical history
+        "current_medications": s.current_medications,
+        "allergies": s.allergies,
+        "past_surgeries": s.past_surgeries,
+        "chronic_conditions": s.chronic_conditions,
+        "family_history": s.family_history,
+        # Lifestyle
+        "diet_type": s.diet_type,
+        "exercise_habits": s.exercise_habits,
+        "sleep_patterns": s.sleep_patterns,
+        "stress_level": s.stress_level,
+        "smoking": s.smoking,
+        "alcohol": s.alcohol,
+        "caffeine": s.caffeine,
+        # Ayurvedic
+        "digestive_patterns": s.digestive_patterns,
+        "elimination_patterns": s.elimination_patterns,
+        "energy_levels": s.energy_levels,
+        "mental_tendencies": s.mental_tendencies,
+        "prior_ayurvedic_care": s.prior_ayurvedic_care,
+        # Reason for visit
+        "chief_concern": s.chief_concern,
+        "symptom_duration": s.symptom_duration,
+        "previous_treatments": s.previous_treatments,
+        "treatment_goals": s.treatment_goals,
+        # Meta
+        "rejection_reason": s.rejection_reason,
+    })
+    return base

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 
 from app.core.config import settings
 from app.core.database import engine, Base, AsyncSessionLocal
-from app.api.routes import auth, practitioners, patients, plans, checkins, portal, ai, billing, supplements, recipes, followups, consultation_notes, assessments, yoga, pranayama
+from app.api.routes import auth, practitioners, patients, plans, checkins, portal, ai, billing, supplements, recipes, followups, consultation_notes, assessments, yoga, pranayama, intake
 
 
 async def _ensure_demo_user():
@@ -96,6 +96,7 @@ app.include_router(yoga.video_router,        prefix="/api/videos",      tags=["v
 app.include_router(yoga.plan_yoga_router,    prefix="/api/plans",       tags=["plan-yoga"])
 app.include_router(pranayama.router,             prefix="/api/pranayama",   tags=["pranayama"])
 app.include_router(pranayama.plan_pranayama_router, prefix="/api/plans",   tags=["plan-pranayama"])
+app.include_router(intake.router,                    prefix="/api/intake",  tags=["intake"])
 
 
 @app.get("/api/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ from app.models.consultation_note import ConsultationNote
 from app.models.dosha_assessment import DoshaAssessment
 from app.models.yoga import YogaAsana, VideoReference, PlanYogaAsana
 from app.models.pranayama import Pranayama, PlanPranayama
+from app.models.intake import IntakeToken, IntakeSubmission
 
 __all__ = [
     "Practitioner", "Patient", "HealthProfile",
@@ -16,4 +17,5 @@ __all__ = [
     "DoshaAssessment",
     "YogaAsana", "VideoReference", "PlanYogaAsana",
     "Pranayama", "PlanPranayama",
+    "IntakeToken", "IntakeSubmission",
 ]

--- a/backend/app/models/intake.py
+++ b/backend/app/models/intake.py
@@ -1,0 +1,96 @@
+"""
+Patient intake form submission and token models.
+Allows practitioners to generate shareable intake links for new patients.
+"""
+import secrets
+import enum
+from datetime import datetime, timezone
+from sqlalchemy import String, Boolean, DateTime, Date, Float, Text, Integer, ForeignKey, Enum as SAEnum
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from app.core.database import Base
+
+
+class IntakeStatus(str, enum.Enum):
+    PENDING  = "pending"
+    REVIEWED = "reviewed"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class IntakeToken(Base):
+    __tablename__ = "intake_tokens"
+
+    id:              Mapped[int]  = mapped_column(primary_key=True)
+    practitioner_id: Mapped[int]  = mapped_column(ForeignKey("practitioners.id"), nullable=False, index=True)
+    token:           Mapped[str]  = mapped_column(String(128), unique=True, nullable=False, default=lambda: secrets.token_urlsafe(48))
+    active:          Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at:      Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+    practitioner: Mapped["Practitioner"] = relationship()  # noqa: F821
+    submission:   Mapped["IntakeSubmission | None"] = relationship(back_populates="token_ref", uselist=False)
+
+    @property
+    def intake_url_path(self) -> str:
+        return f"/intake/{self.token}"
+
+
+class IntakeSubmission(Base):
+    __tablename__ = "intake_submissions"
+
+    id:              Mapped[int] = mapped_column(primary_key=True)
+    practitioner_id: Mapped[int] = mapped_column(ForeignKey("practitioners.id"), nullable=False, index=True)
+    token_id:        Mapped[int] = mapped_column(ForeignKey("intake_tokens.id"), nullable=False, unique=True)
+
+    status: Mapped[IntakeStatus] = mapped_column(
+        SAEnum(IntakeStatus), default=IntakeStatus.PENDING, nullable=False
+    )
+
+    # Timestamps
+    submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    reviewed_at:  Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    # ── Demographics ──────────────────────────────────────────────────────
+    first_name:  Mapped[str]         = mapped_column(String(80), nullable=False)
+    last_name:   Mapped[str]         = mapped_column(String(80), nullable=False)
+    dob:         Mapped[datetime | None] = mapped_column(Date)
+    sex:         Mapped[str | None]  = mapped_column(String(10))
+    email:       Mapped[str | None]  = mapped_column(String(200))
+    phone:       Mapped[str | None]  = mapped_column(String(30))
+    address:     Mapped[str | None]  = mapped_column(String(500))
+    occupation:  Mapped[str | None]  = mapped_column(String(200))
+
+    # ── Medical History ───────────────────────────────────────────────────
+    current_medications: Mapped[str | None] = mapped_column(Text)
+    allergies:           Mapped[str | None] = mapped_column(Text)
+    past_surgeries:      Mapped[str | None] = mapped_column(Text)
+    chronic_conditions:  Mapped[str | None] = mapped_column(Text)
+    family_history:      Mapped[str | None] = mapped_column(Text)
+
+    # ── Lifestyle ─────────────────────────────────────────────────────────
+    diet_type:        Mapped[str | None] = mapped_column(String(50))   # vegetarian, vegan, omnivore, etc.
+    exercise_habits:  Mapped[str | None] = mapped_column(Text)
+    sleep_patterns:   Mapped[str | None] = mapped_column(Text)
+    stress_level:     Mapped[int | None] = mapped_column(Integer)      # 1-5
+    smoking:          Mapped[str | None] = mapped_column(String(50))
+    alcohol:          Mapped[str | None] = mapped_column(String(50))
+    caffeine:         Mapped[str | None] = mapped_column(String(50))
+
+    # ── Ayurvedic Background (optional) ───────────────────────────────────
+    digestive_patterns:     Mapped[str | None] = mapped_column(Text)
+    elimination_patterns:   Mapped[str | None] = mapped_column(Text)
+    energy_levels:          Mapped[str | None] = mapped_column(Text)
+    mental_tendencies:      Mapped[str | None] = mapped_column(Text)
+    prior_ayurvedic_care:   Mapped[str | None] = mapped_column(Text)
+
+    # ── Reason for Visit ──────────────────────────────────────────────────
+    chief_concern:       Mapped[str | None] = mapped_column(Text)
+    symptom_duration:    Mapped[str | None] = mapped_column(String(200))
+    previous_treatments: Mapped[str | None] = mapped_column(Text)
+    treatment_goals:     Mapped[str | None] = mapped_column(Text)
+
+    # ── Rejection reason (set by practitioner) ────────────────────────────
+    rejection_reason: Mapped[str | None] = mapped_column(Text)
+
+    # Relationships
+    practitioner: Mapped["Practitioner"] = relationship()  # noqa: F821
+    token_ref:    Mapped["IntakeToken"]  = relationship(back_populates="submission")


### PR DESCRIPTION
## Summary
- New `IntakeToken` and `IntakeSubmission` models for secure, shareable patient intake forms
- 8 API endpoints: 2 public (load form, submit) + 6 practitioner-authenticated (generate link, list/view/review/approve/reject submissions)
- Approving a submission auto-creates Patient + HealthProfile + CheckInToken records
- Alembic migration 0009 for `intake_tokens` and `intake_submissions` tables

Closes #58

## Test plan
- [ ] Login as demo user, generate an intake link via `POST /api/intake/generate-link`
- [ ] Load the form publicly via `GET /api/intake/form/{token}` — verify practice branding returned
- [ ] Submit intake data via `POST /api/intake/form/{token}/submit` — verify 201 response
- [ ] Verify duplicate submission returns 409
- [ ] List submissions via `GET /api/intake/submissions` — verify submission appears
- [ ] Approve submission via `POST /api/intake/submissions/{id}/approve` — verify patient + health profile created
- [ ] Test reject and delete flows
- [ ] Verify practitioner data isolation (submissions scoped to logged-in practitioner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)